### PR TITLE
修改: 当外层设置最小宽度, 放缩窗体出现横向滚动条时, 可设置监听失效宽度

### DIFF
--- a/packages/hocs/src/ComponentExtendsWidthHoc/ComputeComponentWidthHoc.tsx
+++ b/packages/hocs/src/ComponentExtendsWidthHoc/ComputeComponentWidthHoc.tsx
@@ -10,6 +10,7 @@ export type HocPropsType = {
   getPartOfThemeProps: (name: string, option?: { [key: string]: any }) => {};
   resizeObserverId?: string;
   needComputeSize?: boolean;
+  observerFailureWidth?: number;
 };
 
 const ContainerId = '__tableExtendsWidthHoc';
@@ -22,6 +23,7 @@ export default <PropsType extends HocPropsType>(
       getPartOfThemeProps,
       resizeObserverId = '',
       needComputeSize = true,
+      observerFailureWidth,
     } = props;
     const [parentNodeWidth, setBoxWidth] = useState<number>(0);
 
@@ -89,6 +91,13 @@ export default <PropsType extends HocPropsType>(
 
     const getBodyWidth = () => {
       const { clientWidth } = document.documentElement;
+
+      if (observerFailureWidth) {
+        return clientWidth > observerFailureWidth
+          ? clientWidth
+          : observerFailureWidth;
+      }
+
       return clientWidth;
     };
 

--- a/packages/hocs/src/ComponentExtendsWidthHoc/utils.ts
+++ b/packages/hocs/src/ComponentExtendsWidthHoc/utils.ts
@@ -7,11 +7,18 @@ export const getParentWidth = (boxNode: Element | null): number => {
   if (boxNode) {
     const { parentElement } = boxNode;
     if (parentElement) {
-      const { clientWidth } = parentElement;
+      const { clientWidth, style } = parentElement;
+      const { paddingLeft, paddingRight } = style || {};
+
+      const chosePaddingLeft = paddingLeft || '0';
+      const chosePaddingRight = paddingRight || '0';
+
       if (!clientWidth) {
         return getParentWidth(parentElement);
       }
-      return clientWidth;
+      return (
+        clientWidth - parseInt(chosePaddingLeft) - parseInt(chosePaddingRight)
+      );
     }
   }
   return 0;


### PR DESCRIPTION
当外层设置最小宽度, 放缩窗体出现横向滚动条时, 可设置监听失效宽度