### PR TITLE
修改：

### DIFF
--- a/packages/hocs/src/ComponentExtendsWidthHoc/ComputeComponentWidthHoc.tsx
+++ b/packages/hocs/src/ComponentExtendsWidthHoc/ComputeComponentWidthHoc.tsx
@@ -110,7 +110,9 @@ export default <PropsType extends HocPropsType>(
     };
 
     const onWindowResize = () => {
-      setStateBoxWidth(getCurrentNodeWidth());
+      updateParentNodeWidth();
+      initRule(preObserverNodeWidthRef.current);
+      setStateBoxWidth(getCurrentNodeWidth(preObserverNodeWidthRef.current));
     };
 
     useEffect(() => {


### PR DESCRIPTION
    * 当widow resize事件出发时，更新当前高阶包裹组件父容器的宽度，并重新计算当前元素和observe元素相对于body的占比，然后计算包裹组件宽度；